### PR TITLE
Prevent double LazyMethodCall wrapping in LazyConstantsMeta

### DIFF
--- a/src/antidote/helpers/constants.py
+++ b/src/antidote/helpers/constants.py
@@ -148,7 +148,7 @@ class LazyConstantsMeta(type):
         )
 
         func = resource_class.__dict__[lazy_method]
-        for name, v in resource_class.__dict__.items():
+        for name, v in sorted(resource_class.__dict__.items()):
             if not name.startswith('_') and name.isupper():
                 setattr(resource_class, name, LazyMethodCall(func, singleton=True)(v))
 

--- a/src/antidote/helpers/constants.py
+++ b/src/antidote/helpers/constants.py
@@ -148,7 +148,7 @@ class LazyConstantsMeta(type):
         )
 
         func = resource_class.__dict__[lazy_method]
-        for name, v in sorted(resource_class.__dict__.items()):
+        for name, v in list(resource_class.__dict__.items()):
             if not name.startswith('_') and name.isupper():
                 setattr(resource_class, name, LazyMethodCall(func, singleton=True)(v))
 


### PR DESCRIPTION
The LazyConstantsMeta class wraps certain attributes in a
LazyMethodCall. It does this by looping over the cls.__dict__.items()
dict_items and selectively mutating class attributes.

Mutating the attributes of the underlying dict is causing the loop to
iterate over attributes multiple times, resulting in a LazyMethodCall
wrapping a LazyMethodCall.

See pep-3106 for more information regarding the implied order of
dict_item key ordering.