### PR TITLE
Fix injection error with some type hints

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,17 @@ Most, if not all, the API is annotated with decorators such as :code:`@API.publi
 the given functionality can be relied upon.
 
 
+1.4.2 (2022-06-26)
+==================
+
+
+Bug fix
+-------
+
+- Fix injection error for some union type hints such as :code:`str | List[str]`.
+
+
+
 1.4.1 (2022-06-01)
 ==================
 

--- a/src/antidote/_internal/utils/__init__.py
+++ b/src/antidote/_internal/utils/__init__.py
@@ -34,6 +34,8 @@ Im = TypeVar("Im", bound=Immutable)
 _T = TypeVar("_T")
 _Tp = TypeVar("_Tp", bound=type)
 
+NoneType = type(None)
+
 
 @API.private
 class Default(enum.Enum):
@@ -107,7 +109,7 @@ def is_optional(type_hint: object) -> bool:
     return (
         is_union(type_hint)
         and len(args) == 2
-        and (isinstance(None, args[1]) or isinstance(None, args[0]))
+        and (args[1] is NoneType or args[0] is NoneType)
     )
 
 

--- a/tests/core/test_injection.py
+++ b/tests/core/test_injection.py
@@ -1,6 +1,6 @@
 import functools
 import itertools
-from typing import Iterator, Optional, Sequence, Union
+from typing import Iterator, List, Optional, Sequence, Union
 
 import pytest
 from typing_extensions import Annotated
@@ -398,9 +398,7 @@ def test_with_provide(injector, expected, kwargs):
     # builtins
     [str, int, float, set, list, dict, complex, type, tuple, bytes, bytearray]
     # typing
-    + [Optional, Sequence]
-    # not a class / weird stuff
-    + [1, lambda x: x, object()],
+    + [Optional[int], Sequence[int]]
 )
 def test_ignored_type_hints(injector, type_hint):
     @injector(auto_provide=True)
@@ -1009,3 +1007,10 @@ def test_wrapped_injection():
         inject(g)
 
     assert g() is world.get[MyService]()
+
+
+# https://github.com/Finistere/antidote/issues/56
+def test_problematic_type_hints() -> None:
+    @inject
+    def static(actions: Union[str, List[str]]) -> None:
+        ...


### PR DESCRIPTION
Current check for optional type hints relied on `isinstance`.
However, several type hints such as `List[str]` cannot be used
with it. Replaced it with a `is type(None)` check instead.

Fixes #56